### PR TITLE
Dump the previous run of a container

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -79,7 +79,7 @@ require (
 )
 
 replace (
-	github.com/openshift-kni/k8sreporter v0.0.0 => /home/fedepaol/devel/openshift-kni/k8s-reporter/
+	github.com/openshift-kni/k8sreporter v0.0.0 => ../
 	k8s.io/api => k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery => k8s.io/apimachinery v0.21.1

--- a/reporter.go
+++ b/reporter.go
@@ -166,6 +166,13 @@ func (r *KubernetesReporter) logLogs(since time.Time, dirName string) {
 				fmt.Fprintf(f, "Dumping logs for pod %s-%s-%s\n", pod.Namespace, pod.Name, container.Name)
 				fmt.Fprintln(f, string(logs))
 			}
+
+			logs, err = r.clients.Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{Container: container.Name, SinceTime: &logStart, Previous: true}).DoRaw(context.Background())
+			if err == nil {
+				fmt.Fprintf(f, fileSeparator)
+				fmt.Fprintf(f, "Dumping previous logs for pod %s-%s-%s\n", pod.Namespace, pod.Name, container.Name)
+				fmt.Fprintln(f, string(logs))
+			}
 		}
 
 	}


### PR DESCRIPTION
This should help in case of restarting containers. Also, change the reference to the library to be relative.