### PR TITLE
Clean dir name before dump

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -76,6 +77,7 @@ func New(kubeconfig string, addToScheme AddToScheme, namespaceToLog NamespaceFil
 func (r *KubernetesReporter) Dump(duration time.Duration, dumpSubpath string) {
 	since := time.Now().Add(-duration).Add(-5 * time.Second)
 
+	dumpSubpath = cleanDirName(dumpSubpath)
 	err := os.Mkdir(path.Join(r.reportPath, dumpSubpath), 0755)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		fmt.Fprintf(os.Stderr, "failed to create test dir: %v\n", err)
@@ -221,4 +223,10 @@ func logFileFor(dirName string, testName string, kind string) (*os.File, error) 
 		return nil, err
 	}
 	return f, nil
+}
+
+func cleanDirName(dirName string) string {
+	res := strings.ReplaceAll(dirName, "/", "-")
+	res = strings.ReplaceAll(res, " ", "_")
+	return res
 }


### PR DESCRIPTION
This commit changes the dump function to first invoke the "cleanDirName" function which gets the dumpSubpath, which is usually the test case name. and:
1. replace the white spaces with "_".
2. replace "/" chars with "-".

Those changes are required to make a valid directory name.

This will prevent the creation of directories named like these:
```
'should deploy the injector pod if requested'
'should deploy the operator webhook if requested'
```